### PR TITLE
Making python3 explicit.

### DIFF
--- a/cfg/mission_manager.cfg
+++ b/cfg/mission_manager.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 PACKAGE = "mission_manager"
 
 from dynamic_reconfigure.parameter_generator_catkin import *

--- a/node/mission_manager_node.py
+++ b/node/mission_manager_node.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
-from builtins import str
-from builtins import object
 import rospy
 import smach
 import smach_ros


### PR DESCRIPTION
Making python3 explicit in shebang and removing `from __future__` and `from builtins` imports from `.py` files.

The reasons for this are...

1. For our use-case we are using ROS-Noetic (Python 3) with older code that is Python 2, so need to be explicit with the interpreter. 
2. Noetic is exclusively Python 3, so including the imports can be confusing.